### PR TITLE
Add `mmdet2trt` entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,11 @@ how to create a tensorrt model from mmdet model (converting might take few minut
 ### CLI
 
 ```bash
-# Run mmdet2trt -h for help
-mmdet2trt \
---config ${CONFIG_PATH} \
---checkpoint ${CHECKPOINT_PATH} \
---output ${OUTPUT_PATH}
+mmdet2trt ${CONFIG_PATH} ${CHECKPOINT_PATH} ${OUTPUT_PATH}
 ```
+
+Run mmdet2trt -h for help on optional arguments.
+
 ### Python
 
 ```python

--- a/README.md
+++ b/README.md
@@ -38,8 +38,18 @@ python setup.py develop
 
 how to create a tensorrt model from mmdet model (converting might take few minutes)(Might have some warning when converting.)
 
-```python
+### CLI
 
+```bash
+# Run mmdet2trt -h for help
+mmdet2trt \
+--config ${CONFIG_PATH} \
+--checkpoint ${CHECKPOINT_PATH} \
+--output ${OUTPUT_PATH}
+```
+### Python
+
+```python
 opt_shape_param=[
     [
         [1,3,320,320],      # min shape

--- a/mmdet2trt/mmdet2trt.py
+++ b/mmdet2trt/mmdet2trt.py
@@ -68,3 +68,22 @@ def mmdet2trt(  config,
     if return_warp_model:
         return trt_model, warp_model
     return trt_model
+
+
+def main():                                                                                                                                                                                                                                      
+    parser = ArgumentParser()                                                                                                                                                                                                                    
+    parser.add_argument('config', help='Path to a mmdet Config file')
+    parser.add_argument('checkpoint', help='Path to a mmdet Checkpoint file')
+    parser.add_argument('output', help='Path where tensorrt model will be saved')
+    parser.add_argument("--fp16", type=bool, default=True, help="Enable fp16 inference")
+    parser.add_argument("--save-engine", type=bool, default=True, help="Enable saving TensorRT engine in a separate file.")
+    args = parser.parse_args()
+    trt_model = mmdet2trt(args.config, args.checkpoint, fp16_mode=args.fp16)
+    torch.save(trt_model.state_dict(), args.save_path)
+    if args.save_engine:
+        with open(Path(args.save_path).with_suffix(".engine"), "wb") as f:
+            f.write(trt_model.state_dict()["engine"])
+
+
+if if __name__ == "__main__":
+    main()

--- a/mmdet2trt/mmdet2trt.py
+++ b/mmdet2trt/mmdet2trt.py
@@ -82,9 +82,9 @@ def mmdet2trt(
 
 def main():
     parser = ArgumentParser()
-    parser.add_argument("--config", help="Path to a mmdet Config file")
-    parser.add_argument("--checkpoint", help="Path to a mmdet Checkpoint file")
-    parser.add_argument("--output", help="Path where tensorrt model will be saved")
+    parser.add_argument("config", help="Path to a mmdet Config file")
+    parser.add_argument("checkpoint", help="Path to a mmdet Checkpoint file")
+    parser.add_argument("output", help="Path where tensorrt model will be saved")
     parser.add_argument("--fp16", type=bool, default=True, help="Enable fp16 inference")
     parser.add_argument(
         "--save-engine",

--- a/mmdet2trt/mmdet2trt.py
+++ b/mmdet2trt/mmdet2trt.py
@@ -21,7 +21,7 @@ def mmdet2trt(
     checkpoint,
     device="cuda:0",
     fp16_mode=False,
-    max_workspace_size=1 << 25,
+    max_workspace_size=0.5e9,
     opt_shape_param=None,
     trt_log_level="INFO",
     return_warp_model=False,
@@ -98,8 +98,8 @@ def main():
     parser.add_argument(
         "--max-workspace-size",
         type=int,
-        default=1 << 25,
-        help="The maximum GPU temporary memory which the TensorRT Builder can use at execution time.",
+        default=0.5,
+        help="The maximum `device` (GPU) temporary memory in GB (gigabytes) which TensorRT can use at execution time.",
     )
     parser.add_argument(
         "--min-scale",
@@ -162,7 +162,7 @@ def main():
         args.checkpoint,
         device=args.device,
         fp16_mode=args.fp16,
-        max_workspace_size=args.max_workspace_size,
+        max_workspace_size=args.max_workspace_size * 1e9,
         opt_shape_param=opt_shape_param,
         trt_log_level=args.trt_log_level,
         return_warp_model=args.return_warp_model,

--- a/mmdet2trt/mmdet2trt.py
+++ b/mmdet2trt/mmdet2trt.py
@@ -173,7 +173,7 @@ def main():
     torch.save(trt_model.state_dict(), args.output)
 
     if args.save_engine:
-        logger.info("Saving TRT model engine to: {}".format(Path(args.output).with_suffix(".engine"))
+        logger.info("Saving TRT model engine to: {}".format(Path(args.output).with_suffix(".engine")))
         with open(Path(args.output).with_suffix(".engine"), "wb") as f:
             f.write(trt_model.state_dict()["engine"])
 

--- a/mmdet2trt/mmdet2trt.py
+++ b/mmdet2trt/mmdet2trt.py
@@ -97,7 +97,7 @@ def main():
     )
     parser.add_argument(
         "--max-workspace-gb",
-        type=int,
+        type=float,
         default=0.5,
         help="The maximum `device` (GPU) temporary memory in GB (gigabytes) which TensorRT can use at execution time.",
     )
@@ -162,7 +162,7 @@ def main():
         args.checkpoint,
         device=args.device,
         fp16_mode=args.fp16,
-        max_workspace_size=args.max_workspace_gb * 1e9,
+        max_workspace_size=int(args.max_workspace_gb * 1e9),
         opt_shape_param=opt_shape_param,
         trt_log_level=args.trt_log_level,
         return_warp_model=args.return_warp_model,

--- a/mmdet2trt/mmdet2trt.py
+++ b/mmdet2trt/mmdet2trt.py
@@ -72,9 +72,9 @@ def mmdet2trt(  config,
 
 def main():                                                                                                                                                                                                                                      
     parser = ArgumentParser()                                                                                                                                                                                                                    
-    parser.add_argument('config', help='Path to a mmdet Config file')
-    parser.add_argument('checkpoint', help='Path to a mmdet Checkpoint file')
-    parser.add_argument('output', help='Path where tensorrt model will be saved')
+    parser.add_argument('--config', help='Path to a mmdet Config file')
+    parser.add_argument('--checkpoint', help='Path to a mmdet Checkpoint file')
+    parser.add_argument('--output', help='Path where tensorrt model will be saved')
     parser.add_argument("--fp16", type=bool, default=True, help="Enable fp16 inference")
     parser.add_argument("--save-engine", type=bool, default=True, help="Enable saving TensorRT engine in a separate file.")
     args = parser.parse_args()

--- a/mmdet2trt/mmdet2trt.py
+++ b/mmdet2trt/mmdet2trt.py
@@ -9,6 +9,10 @@ import logging
 import torch
 import time
 
+from pathlib import Path
+from argparse 
+
+
 def mmdet2trt(  config, 
                 checkpoint,
                 device="cuda:0",
@@ -75,10 +79,15 @@ def main():
     parser.add_argument('--config', help='Path to a mmdet Config file')
     parser.add_argument('--checkpoint', help='Path to a mmdet Checkpoint file')
     parser.add_argument('--output', help='Path where tensorrt model will be saved')
-    parser.add_argument("--fp16", type=bool, default=True, help="Enable fp16 inference")
-    parser.add_argument("--save-engine", type=bool, default=True, help="Enable saving TensorRT engine in a separate file.")
+    parser.add_argument(
+        "--fp16", type=bool, default=True, help="Enable fp16 inference")
+    parser.add_argument(
+        "--save-engine", type=bool, default=True, help="Enable saving TensorRT engine in a separate file.")
+    parser.add_argument(
+        '--device', default='cuda:0', help='Device used for inference') 
+   
     args = parser.parse_args()
-    trt_model = mmdet2trt(args.config, args.checkpoint, fp16_mode=args.fp16)
+    trt_model = mmdet2trt(args.config, args.checkpoint, device=args.device, fp16_mode=args.fp16)
     torch.save(trt_model.state_dict(), args.save_path)
     if args.save_engine:
         with open(Path(args.save_path).with_suffix(".engine"), "wb") as f:

--- a/mmdet2trt/mmdet2trt.py
+++ b/mmdet2trt/mmdet2trt.py
@@ -9,90 +9,172 @@ import logging
 import torch
 import time
 
+from argparse import ArgumentParser
 from pathlib import Path
-from argparse 
 
 
-def mmdet2trt(  config, 
-                checkpoint,
-                device="cuda:0",
-                fp16_mode=False,
-                max_workspace_size=1<<25,
-                opt_shape_param=None,
-                log_level = logging.WARN,
-                return_warp_model = False,
-                output_names=["num_detections", "boxes", "scores", "classes"]):
-    
+logger = logging.getLogger("mmdet2trt")
+
+
+def mmdet2trt(
+    config,
+    checkpoint,
+    device="cuda:0",
+    fp16_mode=False,
+    max_workspace_size=1 << 25,
+    opt_shape_param=None,
+    trt_log_level="INFO",
+    return_warp_model=False,
+    output_names=["num_detections", "boxes", "scores", "classes"],
+):
+
     device = torch.device(device)
 
-    logging.basicConfig(level=log_level)
-
-    logging.info("load model from config:{}".format(config))
+    logger.info("Loading model from config: {}".format(config))
     torch_model = init_detector(config, checkpoint=checkpoint, device=device)
     cfg = torch_model.cfg
 
+    logger.info("Wrapping model")
     warp_model = build_warper(torch_model, TwoStageDetectorWarper)
 
     if opt_shape_param is None:
-        img_scale = cfg.test_pipeline[1]['img_scale']
+        img_scale = cfg.test_pipeline[1]["img_scale"]
         min_scale = min(img_scale)
         max_scale = max(img_scale)
         opt_shape_param = [
             [
-                [1, 3, min_scale, min_scale], 
+                [1, 3, min_scale, min_scale],
                 [1, 3, img_scale[1], img_scale[0]],
-                 [1, 3, max_scale, max_scale]
+                [1, 3, max_scale, max_scale],
             ]
         ]
-    
+
     dummy_shape = opt_shape_param[0][1]
     dummy_input = torch.rand(dummy_shape).to(device)
 
-
-    logging.info("model warmup")
+    logger.info("Model warmup")
     with torch.no_grad():
         result = warp_model(dummy_input)
 
-    logging.info("convert model")
+    logger.info("Converting model")
     start = time.time()
     with torch.cuda.device(device), torch.no_grad():
-        trt_model = torch2trt(warp_model, [dummy_input],
-                              log_level=trt.Logger.WARNING,
-                            # log_level=trt.Logger.VERBOSE,
-                              fp16_mode=fp16_mode,
-                              opt_shape_param=opt_shape_param,
-                              max_workspace_size=max_workspace_size,
-                              keep_network=False,
-                              strict_type_constraints=True,
-                              output_names=output_names)
+        trt_model = torch2trt(
+            warp_model,
+            [dummy_input],
+            log_level=getattr(trt.Logger, trt_log_level),
+            fp16_mode=fp16_mode,
+            opt_shape_param=opt_shape_param,
+            max_workspace_size=max_workspace_size,
+            keep_network=False,
+            strict_type_constraints=True,
+            output_names=output_names,
+        )
 
-    duration = time.time()-start
-    logging.info("convert take time {} s".format(duration))
+    duration = time.time() - start
+    logger.info("Conversion took {} s".format(duration))
 
     if return_warp_model:
         return trt_model, warp_model
+
     return trt_model
 
 
-def main():                                                                                                                                                                                                                                      
-    parser = ArgumentParser()                                                                                                                                                                                                                    
-    parser.add_argument('--config', help='Path to a mmdet Config file')
-    parser.add_argument('--checkpoint', help='Path to a mmdet Checkpoint file')
-    parser.add_argument('--output', help='Path where tensorrt model will be saved')
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("--config", help="Path to a mmdet Config file")
+    parser.add_argument("--checkpoint", help="Path to a mmdet Checkpoint file")
+    parser.add_argument("--output", help="Path where tensorrt model will be saved")
+    parser.add_argument("--fp16", type=bool, default=True, help="Enable fp16 inference")
     parser.add_argument(
-        "--fp16", type=bool, default=True, help="Enable fp16 inference")
+        "--save-engine",
+        type=bool,
+        default=True,
+        help="Enable saving TensorRT engine. (will be saved at Path(output).with_suffix('.engine')).",
+    )
     parser.add_argument(
-        "--save-engine", type=bool, default=True, help="Enable saving TensorRT engine in a separate file.")
+        "--device", type=str, default="cuda:0", help="Device used for conversion."
+    )
     parser.add_argument(
-        '--device', default='cuda:0', help='Device used for inference') 
-   
+        "--max-workspace-size",
+        type=int,
+        default=1 << 25,
+        help="The maximum GPU temporary memory which the TensorRT Builder can use at execution time.",
+    )
+    parser.add_argument(
+        "--min-scale",
+        type=int,
+        nargs=2,
+        default=None,
+        help="Minimum input scale in [height, width] order. Only used if all min-scale, opt-scale and max-scale are set.",
+    )
+    parser.add_argument(
+        "--opt-scale",
+        type=int,
+        nargs=2,
+        default=None,
+        help="Optimal input scale in [height, width] order. Only used if all min-scale, opt-scale and max-scale are set.",
+    )
+    parser.add_argument(
+        "--max-scale",
+        type=int,
+        nargs=2,
+        default=None,
+        help="Maximum input scale in [height, width] order. Only used if all min-scale, opt-scale and max-scale are set.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Python logging level.",
+    )
+    parser.add_argument(
+        "--trt-log-level",
+        default="INFO",
+        choices=["VERBOSE", "INFO", "WARNING", "ERROR"],
+        help="TensorRT logging level.",
+    )
+    parser.add_argument(
+        "--return-warp-model",
+        action="store_true",
+        help="Whether to return the created TRTModule instance or not.",
+    )
+    parser.add_argument(
+        "--output-names",
+        nargs=4,
+        type=str,
+        default=["num_detections", "boxes", "scores", "classes"],
+        help="Names for the output nodes of the created TRTModule",
+    )
     args = parser.parse_args()
-    trt_model = mmdet2trt(args.config, args.checkpoint, device=args.device, fp16_mode=args.fp16)
-    torch.save(trt_model.state_dict(), args.save_path)
+
+    logger.setLevel(getattr(logging, args.log_level))
+
+    if all(
+        getattr(args, x) is not None for x in ["min_scale", "opt_scale", "max_scale"]
+    ):
+        opt_shape_param = [args.min_scale, args.opt_scale, args.max_scale]
+    else:
+        opt_shape_param = None
+
+    trt_model = mmdet2trt(
+        args.config,
+        args.checkpoint,
+        device=args.device,
+        fp16_mode=args.fp16,
+        max_workspace_size=args.max_workspace_size,
+        opt_shape_param=opt_shape_param,
+        trt_log_level=args.trt_log_level,
+        return_warp_model=args.return_warp_model,
+        output_names=args.output_names,
+    )
+
+    torch.save(trt_model.state_dict(), args.output)
+
     if args.save_engine:
-        with open(Path(args.save_path).with_suffix(".engine"), "wb") as f:
+        with open(Path(args.output).with_suffix(".engine"), "wb") as f:
             f.write(trt_model.state_dict()["engine"])
 
 
-if if __name__ == "__main__":
+if __name__ == "__main__":
     main()

--- a/mmdet2trt/mmdet2trt.py
+++ b/mmdet2trt/mmdet2trt.py
@@ -169,9 +169,11 @@ def main():
         output_names=args.output_names,
     )
 
+    logger.info("Saving TRT model to: {}".format(args.output))
     torch.save(trt_model.state_dict(), args.output)
 
     if args.save_engine:
+        logger.info("Saving TRT model engine to: {}".format(Path(args.output).with_suffix(".engine"))
         with open(Path(args.output).with_suffix(".engine"), "wb") as f:
             f.write(trt_model.state_dict()["engine"])
 

--- a/mmdet2trt/mmdet2trt.py
+++ b/mmdet2trt/mmdet2trt.py
@@ -96,7 +96,7 @@ def main():
         "--device", type=str, default="cuda:0", help="Device used for conversion."
     )
     parser.add_argument(
-        "--max-workspace-size",
+        "--max-workspace-gb",
         type=int,
         default=0.5,
         help="The maximum `device` (GPU) temporary memory in GB (gigabytes) which TensorRT can use at execution time.",
@@ -162,7 +162,7 @@ def main():
         args.checkpoint,
         device=args.device,
         fp16_mode=args.fp16,
-        max_workspace_size=args.max_workspace_size * 1e9,
+        max_workspace_size=args.max_workspace_gb * 1e9,
         opt_shape_param=opt_shape_param,
         trt_log_level=args.trt_log_level,
         return_warp_model=args.return_warp_model,

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,21 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 from setuptools.command.develop import develop
 from distutils.cmd import Command
+
 # from build import build
 
 package_data = {}
 
 plugins_user_options = [
-    ('plugins', None, 'Build plugins'),
-    ('cuda-dir=', None, 'Location of CUDA (if not default location)'),
-    ('torch-dir=', None, 'Location of PyTorch (if not default location)'),
-    ('trt-inc-dir=', None, 'Location of TensorRT include files (if not default location)'),
-    ('trt-lib-dir=', None, 'Location of TensorRT libraries (if not default location)'),
+    ("plugins", None, "Build plugins"),
+    ("cuda-dir=", None, "Location of CUDA (if not default location)"),
+    ("torch-dir=", None, "Location of PyTorch (if not default location)"),
+    (
+        "trt-inc-dir=",
+        None,
+        "Location of TensorRT include files (if not default location)",
+    ),
+    ("trt-lib-dir=", None, "Location of TensorRT libraries (if not default location)"),
 ]
 
 
@@ -77,7 +82,15 @@ class InstallCommand(install):
 
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""
-    PY_CLEAN_FILES = ['./build', './dist', './__pycache__', './*.pyc', './*.tgz', './*.egg-info']
+
+    PY_CLEAN_FILES = [
+        "./build",
+        "./dist",
+        "./__pycache__",
+        "./*.pyc",
+        "./*.tgz",
+        "./*.egg-info",
+    ]
     description = "Command to tidy up the project root"
     user_options = []
 
@@ -96,7 +109,7 @@ class CleanCommand(Command):
                 if not path.startswith(root_dir):
                     # Die if path in CLEAN_FILES is absolute + outside this directory
                     raise ValueError("%s is not a path inside %s" % (path, root_dir))
-                print('Removing %s' % os.path.relpath(path))
+                print("Removing %s" % os.path.relpath(path))
                 shutil.rmtree(path)
 
         cmd_list = {
@@ -114,14 +127,19 @@ class CleanCommand(Command):
 
 
 setup(
-    name='mmdet2trt',
-    version='0.0.1',
-    description='mmdetection to tensorrt converter',
+    name="mmdet2trt",
+    version="0.0.1",
+    description="mmdetection to tensorrt converter",
     cmdclass={
-        'install': InstallCommand,
-        'clean': CleanCommand,
-        'develop': DevelopCommand,
+        "install": InstallCommand,
+        "clean": CleanCommand,
+        "develop": DevelopCommand,
     },
     packages=find_packages(),
-    package_data=package_data
+    package_data=package_data,
+    entry_points={
+        "console_scripts": [
+            "mmdet2trt = mmdet2trt.mmdet2trt:main",
+            ],
+    },
 )


### PR DESCRIPTION
This P.R. enables the usage of `mmdet2trt` from the command line by adding an entry point to the package.

The README has been updated showing the example usage.