### PR TITLE
Add Docker entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,17 @@ sudo docker build -t mmdet2trt_docker:v1.0 docker/
 Run (will show the help for the CLI entrypoint)
 
 ```shell
-sudo docker run --gpus all -it --rm -v ${your_data_path}:${bind_path}  mmdet2trt_docker:v1.0
+sudo docker run --gpus all -it --rm -v ${your_data_path}:${bind_path} mmdet2trt_docker:v1.0
 ```
 
 Or if you want to open a terminal inside de container:
 ```shell
-sudo docker run --gpus all -it --rm -v ${your_data_path}:${bind_path}  --entrypoint bash mmdet2trt_docker:v1.0
+sudo docker run --gpus all -it --rm -v ${your_data_path}:${bind_path} --entrypoint bash mmdet2trt_docker:v1.0
+```
+
+Example conversion:
+```shell
+sudo docker run --gpus all -it --rm -v ${your_data_path}:${bind_path} mmdet2trt_docker:v1.0 ${bind_path}/config.py ${bind_path}/checkpoint.pth ${bind_path}/output.trt
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,16 @@ Build docker image
 # cuda10.2 tensorrt7.0 pytorch1.6
 sudo docker build -t mmdet2trt_docker:v1.0 docker/
 ```
-Run
+
+Run (will show the help for the CLI entrypoint)
+
 ```shell
 sudo docker run --gpus all -it --rm -v ${your_data_path}:${bind_path}  mmdet2trt_docker:v1.0
+```
+
+Or if you want to open a terminal inside de container:
+```shell
+sudo docker run --gpus all -it --rm -v ${your_data_path}:${bind_path}  --entrypoint bash mmdet2trt_docker:v1.0
 ```
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,8 +38,9 @@ RUN cd /root/space/amirstan_plugin &&\
     mkdir build &&\
     cd build &&\
     cmake .. &&\
-    make -j10 &&\
-    echo "export AMIRSTAN_LIBRARY_PATH=/root/space/amirstan_plugin/build/lib" >> /root/.bashrc
+    make -j10
+
+ENV AMIRSTAN_LIBRARY_PATH=/root/space/amirstan_plugin/build/lib
 
 ### git torch2trt_dynamic
 RUN git clone --depth=1 https://github.com/grimoire/torch2trt_dynamic.git /root/space/torch2trt_dynamic

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,3 +56,6 @@ RUN cd /root/space/mmdetection-to-tensorrt &&\
     python3 setup.py develop
 
 WORKDIR /root/space
+
+CMD [ "--help" ]
+ENTRYPOINT [ "mmdet2trt" ]


### PR DESCRIPTION
This P.R. sets the `mmdet2trt` CLI as the default entrypoint for the docker image. By default it runs with the CMD `help`. 
Examples for using the previous behavior (opening terminal inside the container) and conversion using the new entrypoint had been added to the README 