### PR TITLE
Move importing `core` to the bottom to fix AttributeError

### DIFF
--- a/mmdet2trt/__init__.py
+++ b/mmdet2trt/__init__.py
@@ -1,8 +1,8 @@
 from .apis import *  # noqa: F401,F403
 from .converters import *  # noqa: F401,F403
-from .core import *  # noqa: F401,F403
 from .mmdet2trt import Int8CalibDataset, mask_processor2trt, mmdet2trt
 from .models import *  # noqa: F401,F403
 from .ops import *  # noqa: F401,F403
+from .core import *  # noqa: F401,F403
 
 __all__ = ['Int8CalibDataset', 'mask_processor2trt', 'mmdet2trt']


### PR DESCRIPTION
Apparently in my machine I always got `AttributeError: module 'mmdet2trt' has no attribute 'core'` when importing the module, this happens with both
```
import mmdet2trt
```
and
```
from mmdet2trt import mmdet2trt
```

After some investigation I found out that if I run
```
import mmdet2trt.core
```
I got `AttributeError: module 'mmdet2trt' has no attribute 'ops'`, but
```
import mmdet2trt.ops
```
Worked fine, and after move `from .core import *` to the bottom the thing works