### PR TITLE
Fix cuda version error in dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,15 @@ python setup.py develop
 Build docker image
 
 ```bash
-# cuda11.1 TensorRT7.1 pytorch1.6
+# cuda11.1 TensorRT7.2.2 pytorch1.8 cuda11.1
 sudo docker build -t mmdet2trt_docker:v1.0 docker/
 ```
 
 You can also specify CUDA, Pytorch and Torchvision versions with docker build args by:
 
 ```bash
-# cuda11.1 tensorrt7.1 pytorch1.6
-sudo docker build -t mmdet2trt_docker:v1.0 --build-arg TORCH_VERSION=1.6.0 --build-arg TORCHVISION_VERSION=0.7.0 --docker/
+# cuda11.1 tensorrt7.2.2 pytorch1.6 cuda10.2
+sudo docker build -t mmdet2trt_docker:v1.0 --build-arg TORCH_VERSION=1.6.0 --build-arg TORCHVISION_VERSION=0.7.0 --build-arg CUDA=10.2 --docker/
 ```
 
 Run (will show the help for the CLI entrypoint)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM nvcr.io/nvidia/tensorrt:20.12-py3
 
 ARG CUDA=11.1
-ARG TORCH_VERSION=1.6.0
-ARG TORCHVISION_VERSION=0.7.0
+ARG TORCH_VERSION=1.8.0
+ARG TORCHVISION_VERSION=0.9.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -18,7 +18,8 @@ RUN mkdir ~/space &&\
 # COPY ./pip.conf /root/.pip
 
 ### pytorch
-RUN pip3 install torch==${TORCH_VERSION} torchvision==${TORCHVISION_VERSION}
+RUN pip3 install torch==${TORCH_VERSION}+cu${CUDA//./} torchvision==${TORCHVISION_VERSION}+cu${CUDA//./} -f https://download.pytorch.org/whl/torch_stable.html
+
 
 ### install mmcv
 RUN pip3 install pytest-runner


### PR DESCRIPTION
Close #82 

You can check Pytorch works with sm_86 arch by running.

```console
$ docker run --gpus all -it --rm  --entrypoint python3 mmdet2trt_docker:v1.0 -c "import torch; print(torch.cuda.get_arch_list())"
['sm_37', 'sm_50', 'sm_60', 'sm_70', 'sm_75', 'sm_80', 'sm_86']
```