### PR TITLE
Fixed build on OpenCV 4.x, TensorRT 8.x. Fixed TensorRT version cmake info

### DIFF
--- a/demo/cpp/FindTensorRT.cmake
+++ b/demo/cpp/FindTensorRT.cmake
@@ -69,6 +69,17 @@ if(TensorRT_INCLUDE_DIR AND EXISTS "${TensorRT_INCLUDE_DIR}/NvInfer.h")
     set(TensorRT_VERSION_STRING "${TensorRT_VERSION_MAJOR}.${TensorRT_VERSION_MINOR}.${TensorRT_VERSION_PATCH}")
 endif()
 
+if(TensorRT_INCLUDE_DIR AND EXISTS "${TensorRT_INCLUDE_DIR}/NvInferVersion.h")
+    file(STRINGS "${TensorRT_INCLUDE_DIR}/NvInferVersion.h" TensorRT_MAJOR REGEX "^#define NV_TENSORRT_MAJOR [0-9]+.*$")
+    file(STRINGS "${TensorRT_INCLUDE_DIR}/NvInferVersion.h" TensorRT_MINOR REGEX "^#define NV_TENSORRT_MINOR [0-9]+.*$")
+    file(STRINGS "${TensorRT_INCLUDE_DIR}/NvInferVersion.h" TensorRT_PATCH REGEX "^#define NV_TENSORRT_PATCH [0-9]+.*$")
+
+    string(REGEX REPLACE "^#define NV_TENSORRT_MAJOR ([0-9]+).*$" "\\1" TensorRT_VERSION_MAJOR "${TensorRT_MAJOR}")
+    string(REGEX REPLACE "^#define NV_TENSORRT_MINOR ([0-9]+).*$" "\\1" TensorRT_VERSION_MINOR "${TensorRT_MINOR}")
+    string(REGEX REPLACE "^#define NV_TENSORRT_PATCH ([0-9]+).*$" "\\1" TensorRT_VERSION_PATCH "${TensorRT_PATCH}")
+    set(TensorRT_VERSION_STRING "${TensorRT_VERSION_MAJOR}.${TensorRT_VERSION_MINOR}.${TensorRT_VERSION_PATCH}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(TensorRT REQUIRED_VARS TensorRT_LIBRARY TensorRT_INCLUDE_DIR VERSION_VAR TensorRT_VERSION_STRING)
 

--- a/demo/cpp/inout_transform.h
+++ b/demo/cpp/inout_transform.h
@@ -37,7 +37,7 @@ class ImageTransformer {
         //  1. Resize before normalization - smaller image takes less time to be transformed
         cv::Size2d scale_factor = resize_keep_aspect_ratio(input_image, dst_size, output_image);
         //  2. To RGB, FP32
-        cv::cvtColor(output_image, output_image, CV_BGR2RGB);
+        cv::cvtColor(output_image, output_image, cv::COLOR_BGR2RGB);
         //  3. To FP32 and normalize
         output_image.convertTo(output_image, CV_32FC3);
         cv::Mat rgb[3];

--- a/demo/cpp/main.cpp
+++ b/demo/cpp/main.cpp
@@ -14,11 +14,18 @@
 #include "data.h"
 #include "inout_transform.h"
 
+#include "NvInferVersion.h"
+
+#if NV_TENSORRT_MAJOR > 7
+#define PLUGIN_NOEXCEPT noexcept
+#else
+#define PLUGIN_NOEXCEPT
+#endif
 
 //  Some required utilities
 class Logger : public nvinfer1::ILogger {
 public:
-    void log(Severity severity, const char* msg) noexcept override {
+    void log(Severity severity, const char* msg) PLUGIN_NOEXCEPT override {
         // remove this 'if' if you need more logged info
         if ((severity == Severity::kERROR) || (severity == Severity::kINTERNAL_ERROR)) {
             std::cout << msg << std::endl;

--- a/demo/cpp/main.cpp
+++ b/demo/cpp/main.cpp
@@ -18,7 +18,7 @@
 //  Some required utilities
 class Logger : public nvinfer1::ILogger {
 public:
-    void log(Severity severity, const char* msg) override {
+    void log(Severity severity, const char* msg) noexcept override {
         // remove this 'if' if you need more logged info
         if ((severity == Severity::kERROR) || (severity == Severity::kINTERNAL_ERROR)) {
             std::cout << msg << std::endl;


### PR DESCRIPTION
* Fixed cpp demo build on OpenCV 4.x (BGR2RGB has been renamed) 
* Fixed TensorRT version info in FindTensorRT.cmake (version info has moved to a separate header). 
* Fixed build error caused by logger (Logger, https://forums.developer.nvidia.com/t/looser-throw-specifier-for-virtual-void-logger-log/187963)
```
**mmdetection-to-tensorrt/demo/cpp/main.cpp:21:10: error: looser throw specifier for ‘virtual void Logger::log(nvinfer1::ILogger::Severity, const char*)’
```

Builds successfully on TensorRT 8.2.1, Opencv 4.5.2