### PR TITLE
[fix] fix a bug for mask inference when mask num_dets == 0

### DIFF
--- a/mmdet2trt/apis/inference.py
+++ b/mmdet2trt/apis/inference.py
@@ -182,19 +182,20 @@ class TRTDetector(BaseDetector):
                 masks = masks.detach().cpu().numpy()
                 num_classes = len(self.CLASSES)
                 class_agnostic = True
-                segms_results = []
-                for i in range(batch_size):
-                    segms_results = FCNMaskHead.get_seg_masks(
-                        Addict(
-                            num_classes=num_classes,
-                            class_agnostic=class_agnostic),
-                        masks,
-                        old_dets,
-                        labels,
-                        rcnn_test_cfg=Addict(mask_thr_binary=0.5),
-                        ori_shape=img_metas[i]['ori_shape'],
-                        scale_factor=scale_factor,
-                        rescale=rescale)
+                segms_results = [[] for _ in range(num_classes)]
+                if num_dets>0:
+                    for i in range(batch_size):
+                        segms_results = FCNMaskHead.get_seg_masks(
+                            Addict(
+                                num_classes=num_classes,
+                                class_agnostic=class_agnostic),
+                            masks,
+                            old_dets,
+                            labels,
+                            rcnn_test_cfg=Addict(mask_thr_binary=0.5),
+                            ori_shape=img_metas[i]['ori_shape'],
+                            scale_factor=scale_factor,
+                            rescale=rescale)
                 results.append((dets_results, segms_results))
             else:
                 results.append(dets_results)


### PR DESCRIPTION
The original will raise an error if the `num_dets` ==0. 